### PR TITLE
remove audit support

### DIFF
--- a/UI/src/components/features/RipaFormContainer.vue
+++ b/UI/src/components/features/RipaFormContainer.vue
@@ -164,12 +164,7 @@ export default {
   },
 
   methods: {
-    ...mapActions([
-      'checkTextForPii',
-      'checkGpsLocation',
-      'putOfficerUser',
-      'putOfficerAudit',
-    ]),
+    ...mapActions(['checkTextForPii', 'checkGpsLocation', 'putOfficerUser']),
 
     handleClose() {
       this.showUserDialog = false
@@ -184,8 +179,7 @@ export default {
       this.setLastLocation(this.stop)
     },
 
-    async handleSubmitAudit(audit, route) {
-      await this.putOfficerAudit(audit)
+    handleSubmitAudit(route) {
       this.$router.push(route)
     },
 

--- a/UI/src/components/mixins/RipaEditStopMixin.vue
+++ b/UI/src/components/mixins/RipaEditStopMixin.vue
@@ -19,10 +19,6 @@ export default {
       localStorage.setItem('ripa_form_stop', JSON.stringify(stop))
       localStorage.setItem('ripa_form_full_stop', JSON.stringify(fullStop))
       localStorage.setItem(
-        'ripa_form_submitted_api_stop',
-        JSON.stringify(apiStop),
-      )
-      localStorage.setItem(
         'ripa_form_submitted_submissions',
         JSON.stringify(sortedSubmissions),
       )

--- a/UI/src/components/mixins/RipaFormContainerMixin.vue
+++ b/UI/src/components/mixins/RipaFormContainerMixin.vue
@@ -424,7 +424,6 @@ export default {
       localStorage.removeItem('ripa_form_saved_full_stop')
       localStorage.removeItem('ripa_form_step_index')
       localStorage.removeItem('ripa_form_stop')
-      localStorage.removeItem('ripa_form_submitted_api_stop')
       localStorage.removeItem('ripa_form_submitted_submissions')
     },
 

--- a/UI/src/components/organisms/RipaFormWrapper.vue
+++ b/UI/src/components/organisms/RipaFormWrapper.vue
@@ -330,20 +330,6 @@ export default {
   },
 
   methods: {
-    getAuditRecord() {
-      const newApiStop = this.getApiStop
-      const oldApiStop = localStorage.getItem('ripa_form_submitted_api_stop')
-      const explanation = this.stop.editStopExplanation || null
-
-      return {
-        id: new Date().getTime(),
-        editStopExplanation: explanation,
-        submitTimestamp: new Date(),
-        oldApiStop: oldApiStop ? JSON.parse(oldApiStop) : null,
-        newApiStop,
-      }
-    },
-
     handleDebugger() {
       this.showDialog = true
     },
@@ -557,7 +543,7 @@ export default {
             const route = localStorage.getItem('ripa_form_edit_route')
             const parsedRoute = route || '/'
             if (this.adminEditing && this.onSubmitAudit) {
-              this.onSubmitAudit(this.getAuditRecord(), parsedRoute)
+              this.onSubmitAudit(parsedRoute)
             }
             if (this.onCancelForm) {
               this.onCancelForm()

--- a/UI/src/store/index.js
+++ b/UI/src/store/index.js
@@ -623,32 +623,6 @@ export default new Vuex.Store({
         })
     },
 
-    putOfficerAudit({ state }, audit) {
-      const mappedAudit = {
-        ...audit,
-        adminOfficerId: state.user.officerId,
-      }
-
-      return axios
-        .put(
-          `${state.apiConfig.apiBaseUrl}audit/PutAudit/${audit.id}`,
-          mappedAudit,
-          {
-            headers: {
-              'Content-Type': 'application/json',
-              'Ocp-Apim-Subscription-Key': state.apiConfig.apiSubscription,
-              'Cache-Control': 'no-cache',
-            },
-          },
-        )
-        .catch(error => {
-          console.log(
-            'There was an error saving the officer stop audit record.',
-            error,
-          )
-        })
-    },
-
     getAdminBeats({ commit, state }) {
       return axios
         .get(`${state.apiConfig.apiBaseUrl}domain/GetBeats`, {

--- a/UI/src/stories/containers/RipaFormContainer.vue
+++ b/UI/src/stories/containers/RipaFormContainer.vue
@@ -43,7 +43,6 @@
       :on-open-template="handleOpenTemplate"
       :on-step-index-change="handleStepIndexChange"
       :on-submit-stop="handleSubmitStop"
-      :on-submit-audit="handleSubmitAudit"
       @input="handleInput"
     ></ripa-form-template>
 
@@ -168,10 +167,6 @@ export default {
     handleSubmitStop(apiStop) {
       this.setLastLocation(this.stop)
       console.log('SUBMIT STOP', apiStop)
-    },
-
-    handleSubmitAudit(audit) {
-      console.log('SUBMIT AUDIT', audit)
     },
 
     validateLocationForPii(textValue) {


### PR DESCRIPTION
Remove UI audit support. Note: This will require passing the edit reason text to the PutStop at some point once it is supported.