### PR TITLE
Fix editing stops

### DIFF
--- a/UI/src/components/mixins/RipaEditStopMixin.vue
+++ b/UI/src/components/mixins/RipaEditStopMixin.vue
@@ -1,5 +1,6 @@
 <script>
 import { apiStopToFullStop, fullStopToStop } from '@/utilities/stop'
+import router from '@/router'
 
 export default {
   methods: {
@@ -22,6 +23,7 @@ export default {
         'ripa_form_submitted_submissions',
         JSON.stringify(sortedSubmissions),
       )
+      router.push('/')
     },
   },
 }


### PR DESCRIPTION
This fixes a bug where editing stops was not working.  Just needed to fix the mixin function.

To verify:
- go to admin/stops and verify you can click the pencil icon to be taken to the form to edit stops.