### PR TITLE
Fix to check for the submission id upon submitting stops

### DIFF
--- a/UI/src/components/features/RipaAdminContainer.vue
+++ b/UI/src/components/features/RipaAdminContainer.vue
@@ -260,7 +260,7 @@ export default {
       this.loading = true
       const submissionResults = await Promise.all([this.submitStops(stops)])
       this.loading = false
-      if (submissionResults) {
+      if (!submissionResults[0].submissionId) {
         // show the error message, no redirec
         this.snackbarText = `Submission error: ${submissionResults[0]}`
         this.snackbarVisible = true
@@ -288,7 +288,7 @@ export default {
         this.submitAllStops(filterData),
       ])
       this.loading = false
-      if (submissionResults) {
+      if (!submissionResults[0].submissionId) {
         this.snackbarText = `Submission error: ${submissionResults[0]}`
         this.snackbarVisible = true
       } else {


### PR DESCRIPTION
This puts in a check for the submission ID upon the return of the API call.  If we get a submission ID back, we know our stops submitted successfully.