### PR TITLE
Add in error count and officer name to the submissions grid

### DIFF
--- a/UI/src/components/molecules/RipaSubmissionsGrid.vue
+++ b/UI/src/components/molecules/RipaSubmissionsGrid.vue
@@ -134,6 +134,12 @@ export default {
           sortable: true,
           sortName: 'recordCount',
         },
+        {
+          text: 'Officer Name',
+          value: 'officerName',
+          sortName: 'officerName',
+          sortable: true,
+        },
         { text: 'Actions', value: 'actions', sortable: false, width: '100' },
       ],
       editedIndex: -1,
@@ -176,9 +182,19 @@ export default {
       }
     },
     getFilterStatus() {
+      let sortOrder = this.sortDesc
+      if (Array.isArray(this.sortDesc)) {
+        sortOrder = this.sortDesc[0]
+      }
       return {
         submissionFromDate: this.submissionFromDate,
         submissionToDate: this.submissionToDate,
+        orderBy:
+          // if the column sort name is null, default to sorting by the stop date
+          this.getColumnSortName() === null
+            ? 'dateSubmitted'
+            : this.getColumnSortName(),
+        order: sortOrder || sortOrder === undefined ? 'Desc' : 'Asc',
       }
     },
   },

--- a/UI/src/components/molecules/RipaSubmissionsGrid.vue
+++ b/UI/src/components/molecules/RipaSubmissionsGrid.vue
@@ -140,6 +140,12 @@ export default {
           sortName: 'officerName',
           sortable: true,
         },
+        {
+          text: 'Error Count',
+          value: '',
+          sortName: 'errorCount',
+          sortable: false,
+        },
         { text: 'Actions', value: 'actions', sortable: false, width: '100' },
       ],
       editedIndex: -1,

--- a/UI/src/components/molecules/RipaSubmissionsGrid.vue
+++ b/UI/src/components/molecules/RipaSubmissionsGrid.vue
@@ -142,7 +142,7 @@ export default {
         },
         {
           text: 'Error Count',
-          value: '',
+          value: 'errorCount',
           sortName: 'errorCount',
           sortable: false,
         },


### PR DESCRIPTION
This adds the error count and officer name to the submissions grid.