### PR TITLE
Jake bug 1225 admin user dialog

### DIFF
--- a/UI/src/components/molecules/RipaSubmission.vue
+++ b/UI/src/components/molecules/RipaSubmission.vue
@@ -99,7 +99,7 @@
             <div class="stopError" v-html="item.error"></div>
           </template>
           <template v-slot:item.edited="{ item }">
-            {{ item.IsEdited ? 'Yes' : 'No' }}
+            {{ item.isEdited ? 'Yes' : 'No' }}
           </template>
           <template v-slot:no-data>
             <div>No Stops Found in This Submission</div>

--- a/UI/src/components/molecules/RipaUser.vue
+++ b/UI/src/components/molecules/RipaUser.vue
@@ -1,6 +1,43 @@
 <template>
   <div class="ripa-user">
     <v-container>
+      <template v-if="admin">
+        <v-row no-gutters>
+          <v-col cols="12" sm="12">
+            <ripa-text-input
+              v-model="model.id"
+              label="ID"
+              :disabled="isRowKeyDisabled"
+            >
+            </ripa-text-input>
+          </v-col>
+        </v-row>
+
+        <v-row no-gutters>
+          <v-col cols="12" sm="12" md="6">
+            <div class="md:tw-mr-4">
+              <ripa-text-input
+                v-model="model.firstName"
+                label="First Name"
+                :rules="firstNameRules"
+              >
+              </ripa-text-input>
+            </div>
+          </v-col>
+
+          <v-col cols="12" sm="12" md="6">
+            <div>
+              <ripa-text-input
+                v-model="model.lastName"
+                label="Last Name"
+                :rules="lastNameRules"
+              >
+              </ripa-text-input>
+            </div>
+          </v-col>
+        </v-row>
+      </template>
+
       <v-row no-gutters>
         <v-col cols="12" sm="12" md="6">
           <div class="md:tw-mr-4">
@@ -20,6 +57,7 @@
               v-model="model.yearsExperience"
               label="Years of Experience"
               :rules="yearsExperienceRules"
+              @input="handleInput"
             >
             </ripa-number-input>
           </div>
@@ -32,7 +70,7 @@
             <ripa-text-input
               v-model="model.agency"
               label="Agency"
-              :disabled="!isInvalidUser"
+              :disabled="!admin"
               :rules="agencyRules"
               @input="handleInput"
             >
@@ -107,6 +145,8 @@ export default {
       ],
       agencyRules: [v => !!v || 'An agency is required'],
       assignmentRules: [v => !!v || 'An assignment is required'],
+      firstNameRules: [v => !!v || 'A first name is required'],
+      lastNameRules: [v => !!v || 'A last name is required'],
       assignmentItems: OFFICER_ASSIGNMENTS,
       viewModel: this.value,
     }
@@ -188,9 +228,13 @@ export default {
       type: Boolean,
       default: false,
     },
-    isInvalidUser: {
+    admin: {
       type: Boolean,
       default: false,
+    },
+    isRowKeyDisabled: {
+      type: Boolean,
+      default: true,
     },
   },
 }

--- a/UI/src/components/molecules/RipaUserDialog.vue
+++ b/UI/src/components/molecules/RipaUserDialog.vue
@@ -108,10 +108,6 @@ export default {
       }
       this.handleClose()
     },
-
-    handleInput() {
-      console.log(this.viewModelUser)
-    },
   },
 
   watch: {

--- a/UI/src/components/molecules/RipaUserDialog.vue
+++ b/UI/src/components/molecules/RipaUserDialog.vue
@@ -2,7 +2,7 @@
   <v-dialog v-model="modelDialog" max-width="650px" persistent>
     <v-card>
       <v-card-title>
-        <span>Manage User</span>
+        <span>{{ this.formTitle }}</span>
       </v-card-title>
 
       <v-card-text>
@@ -21,6 +21,9 @@
             <ripa-user
               v-model="modelUser"
               :is-invalid-user="isInvalidUser"
+              :admin="admin"
+              :is-row-key-disabled="isRowKeyDisabled"
+              @input="handleInput"
             ></ripa-user>
           </template>
         </v-form>
@@ -87,7 +90,7 @@ export default {
   methods: {
     handleClose() {
       this.isFormValid = this.$refs.dialogForm.validate()
-      if (!this.isFormValid) {
+      if (!this.isFormValid && !this.admin) {
         return
       }
       if (this.onClose) {
@@ -104,6 +107,10 @@ export default {
         this.onSave(this.viewModelUser)
       }
       this.handleClose()
+    },
+
+    handleInput() {
+      console.log(this.viewModelUser)
     },
   },
 
@@ -140,6 +147,18 @@ export default {
     onSave: {
       type: Function,
       default: () => {},
+    },
+    admin: {
+      type: Boolean,
+      default: false,
+    },
+    isRowKeyDisabled: {
+      type: Boolean,
+      default: true,
+    },
+    formTitle: {
+      type: String,
+      default: 'Manage User',
     },
   },
 }

--- a/UI/src/components/molecules/RipaUsersGrid.vue
+++ b/UI/src/components/molecules/RipaUsersGrid.vue
@@ -57,7 +57,6 @@
 
 <script>
 import RipaUserDialog from '@/components/molecules/RipaUserDialog'
-import { format } from 'date-fns'
 
 export default {
   name: 'ripa-users-grid',

--- a/UI/src/components/molecules/RipaUsersGrid.vue
+++ b/UI/src/components/molecules/RipaUsersGrid.vue
@@ -22,6 +22,8 @@
             >Admin: Maintain Users</v-toolbar-title
           >
           <v-spacer></v-spacer>
+          <!--
+            For now I don't think we need this ability
           <v-btn
             color="primary"
             dark
@@ -30,6 +32,7 @@
           >
             New User
           </v-btn>
+          -->
 
           <ripa-user-dialog
             :admin="true"

--- a/UI/src/components/molecules/RipaUsersGrid.vue
+++ b/UI/src/components/molecules/RipaUsersGrid.vue
@@ -22,95 +22,25 @@
             >Admin: Maintain Users</v-toolbar-title
           >
           <v-spacer></v-spacer>
-          <v-dialog v-model="dialog" max-width="500px" persistent>
-            <template v-slot:activator="{ on, attrs }">
-              <v-btn
-                color="primary"
-                dark
-                class="tw-mb-2"
-                v-bind="attrs"
-                v-on="on"
-              >
-                New Item
-              </v-btn>
-            </template>
-            <v-card>
-              <v-card-title>
-                <span>{{ formTitle }}</span>
-              </v-card-title>
+          <v-btn
+            color="primary"
+            dark
+            class="tw-mb-2"
+            @click="editItem(defaultItem)"
+          >
+            New User
+          </v-btn>
 
-              <v-card-text>
-                <v-container>
-                  <v-row>
-                    <v-col cols="12">
-                      <v-text-field
-                        v-model="editedItem.id"
-                        :disabled="isRowKeyDisabled"
-                        label="ID"
-                      ></v-text-field>
-                    </v-col>
-                    <v-col cols="12">
-                      <v-text-field
-                        v-model="editedItem.firstName"
-                        label="First Name"
-                      ></v-text-field>
-                    </v-col>
-                    <v-col cols="12">
-                      <v-text-field
-                        v-model="editedItem.lastName"
-                        label="Last Name"
-                      ></v-text-field>
-                    </v-col>
-                    <v-col cols="12">
-                      <v-text-field
-                        v-model="editedItem.agency"
-                        label="Agency"
-                      ></v-text-field>
-                    </v-col>
-                    <v-col cols="12">
-                      <ripa-date-picker
-                        v-model="editedItem.startDate"
-                        label="Start Date"
-                      ></ripa-date-picker>
-                    </v-col>
-                    <v-col cols="12">
-                      <v-text-field
-                        v-model="editedItem.yearsExperience"
-                        label="Years Experience"
-                      ></v-text-field>
-                    </v-col>
-                    <v-col cols="12">
-                      <v-text-field
-                        v-model="editedItem.assignment"
-                        label="Assignment"
-                      ></v-text-field>
-                    </v-col>
-                    <v-col cols="12">
-                      <v-text-field
-                        v-model="editedItem.otherType"
-                        label="Other Type"
-                      ></v-text-field>
-                    </v-col>
-                  </v-row>
-                </v-container>
-              </v-card-text>
-
-              <v-card-actions>
-                <v-spacer></v-spacer>
-                <v-btn color="blue darken-1" text @click="close">
-                  Cancel
-                </v-btn>
-                <v-btn
-                  color="blue darken-1"
-                  text
-                  :disabled="isDuplicateKey"
-                  @click="save"
-                >
-                  Save
-                </v-btn>
-              </v-card-actions>
-            </v-card>
-          </v-dialog>
+          <ripa-user-dialog
+            :admin="true"
+            :user="editedItem"
+            :showDialog="dialog"
+            :on-close="close"
+            :on-save="save"
+            :is-row-key-disabled="isRowKeyDisabled"
+            :form-title="formTitle"
+          >
+          </ripa-user-dialog>
         </v-toolbar>
       </template>
       <template v-slot:item.actions="{ item }">
@@ -126,14 +56,14 @@
 </template>
 
 <script>
-import RipaDatePicker from '@/components/atoms/RipaDatePicker'
+import RipaUserDialog from '@/components/molecules/RipaUserDialog'
 import { format } from 'date-fns'
 
 export default {
   name: 'ripa-users-grid',
 
   components: {
-    RipaDatePicker,
+    RipaUserDialog,
   },
 
   data() {
@@ -167,6 +97,8 @@ export default {
         lastName: '',
         startDate: '',
         agency: '',
+        assignment: 0,
+        yearsExperience: '',
       },
       defaultItem: {
         id: '',
@@ -174,13 +106,15 @@ export default {
         lastName: '',
         startDate: '',
         agency: '',
+        assignment: 0,
+        yearsExperience: '',
       },
     }
   },
 
   computed: {
     formTitle() {
-      return this.editedIndex === -1 ? 'New Item' : 'Edit Item'
+      return this.editedIndex === -1 ? 'New User' : 'Edit User'
     },
 
     isRowKeyDisabled() {
@@ -208,6 +142,7 @@ export default {
     editItem(item) {
       this.editedIndex = this.users.indexOf(item)
       this.editedItem = Object.assign({}, item)
+      this.editedItem.assignment = Number(this.editedItem.assignment)
       this.dialog = true
     },
 
@@ -222,11 +157,9 @@ export default {
     save() {
       this.editedName = `${this.editedItem.fullName} ${this.editedItem.lastName}`
       if (this.editedIndex > -1) {
+        this.editedItem.assignment = Number(this.editedItem.assignment)
         Object.assign(this.users[this.editedIndex], this.editedItem)
       } else {
-        this.editedItem.officerId =
-          format(new Date(), 'yyMMdd') +
-          (Math.floor(Math.random() * 999) + 100).toString()
         this.users.push(this.editedItem)
       }
 


### PR DESCRIPTION
Currently admin users can edit a user with invalid data.  I modified the RipaUserDialogue and RipaUser molecules to check if the user is an admin and present different fields.  This allows administrators to edit users with the current application's functionality but include the validation fields.