### PR TITLE
Pii check offline stops

### DIFF
--- a/Functions/RIPA.Functions.Common.Models/Stop.cs
+++ b/Functions/RIPA.Functions.Common.Models/Stop.cs
@@ -1,7 +1,5 @@
 ﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 
 namespace RIPA.Functions.Common.Models
@@ -274,5 +272,6 @@ namespace RIPA.Functions.Common.Models
         public string EntityText { get; set; }
         public string ConfidenceScore { get; set; }
         public string Category { get; set; }
+        public string Source { get; set; }
     }
 }

--- a/UI/src/components/atoms/RipaTextInput.vue
+++ b/UI/src/components/atoms/RipaTextInput.vue
@@ -61,8 +61,9 @@ export default {
     },
 
     handleBlur(event) {
+      const oldVal = this.value
       this.viewModel = this.parseText(event.target.value)
-      this.handleInput(this.viewModel)
+      this.handleInput(this.viewModel, oldVal)
     },
 
     parseText(newVal) {
@@ -76,10 +77,12 @@ export default {
       return parsedText
     },
 
-    handleInput(newVal) {
+    handleInput(newVal, oldVal) {
       this.$nextTick(() => {
         this.viewModel = newVal
-        this.$emit('input', this.viewModel)
+        if (oldVal !== newVal) {
+          this.$emit('input', this.viewModel)
+        }
       })
     },
   },

--- a/UI/src/components/features/RipaFormContainer.vue
+++ b/UI/src/components/features/RipaFormContainer.vue
@@ -158,6 +158,9 @@ export default {
     return {
       snackbarNotOnlineVisible: false,
       snackbarGpsVisible: false,
+      locationSource: 'Location',
+      basisForSearchSource: 'Basis for Search',
+      stopReasonSource: 'Stop Reason',
     }
   },
 
@@ -246,21 +249,29 @@ export default {
         this.loadingPiiStep1 = true
         const response = await this.checkTextForPii(trimmedTextValue)
         this.stop = Object.assign({}, this.stop)
+
         if (this.stop.location) {
           this.stop.location.piiFound =
             response && response.piiEntities && response.piiEntities.length > 0
           this.stop.isPiiFound =
             this.stop.isPiiFound || this.stop.location.piiFound
         }
+
         if (!this.stop.location.piiFound && this.stop.piiEntities?.length > 0) {
           this.stop.piiEntities = this.stop.piiEntities.filter(
-            e => e.source !== 'location',
+            e => e.source !== this.locationSource,
           )
         }
+
         if (response.piiEntities.length > 0) {
-          this.stop.piiEntities = this.stop.piiEntities || []
+          this.stop.piiEntities = this.stop.piiEntities
+            ? this.stop.piiEntities.filter(
+                e => e.source !== this.locationSource,
+              )
+            : []
+
           for (const entity of response.piiEntities) {
-            entity.source = 'location'
+            entity.source = this.locationSource
             this.stop.piiEntities.push(entity)
           }
         }
@@ -279,24 +290,31 @@ export default {
         this.loadingPiiStep3 = true
         const response = await this.checkTextForPii(trimmedTextValue)
         this.stop = Object.assign({}, this.stop)
+
         if (this.stop.stopReason) {
           this.stop.stopReason.reasonForStopPiiFound =
             response && response.piiEntities && response.piiEntities.length > 0
           this.stop.isPiiFound =
             this.stop.isPiiFound || this.stop.stopReason.reasonForStopPiiFound
         }
+
         if (
           !this.stop.stopReason.reasonForStopPiiFound &&
           this.stop.piiEntities?.length > 0
         ) {
           this.stop.piiEntities = this.stop.piiEntities.filter(
-            e => e.source !== 'stopReason',
+            e => e.source !== this.stopReasonSource,
           )
         }
+
         if (response.piiEntities.length > 0) {
-          this.stop.piiEntities = this.stop.piiEntities || []
+          this.stop.piiEntities = this.stop.piiEntities
+            ? this.stop.piiEntities.filter(
+                e => e.source !== this.stopReasonSource,
+              )
+            : []
           for (const entity of response.piiEntities) {
-            entity.source = 'stopReason'
+            entity.source = this.stopReasonSource
             this.stop.piiEntities.push(entity)
           }
         }
@@ -315,6 +333,7 @@ export default {
         this.loadingPiiStep4 = true
         const response = await this.checkTextForPii(trimmedTextValue)
         this.stop = Object.assign({}, this.stop)
+
         if (this.stop.actionsTaken) {
           this.stop.actionsTaken.basisForSearchPiiFound =
             response && response.piiEntities && response.piiEntities.length > 0
@@ -322,18 +341,24 @@ export default {
             this.stop.isPiiFound ||
             this.stop.actionsTaken.basisForSearchPiiFound
         }
+
         if (
           !this.stop.actionsTaken.basisForSearchPiiFound &&
           this.stop.piiEntities?.length > 0
         ) {
           this.stop.piiEntities = this.stop.piiEntities.filter(
-            e => e.source !== 'basisForSearch',
+            e => e.source !== this.basisForSearchSource,
           )
         }
+
         if (response.piiEntities.length > 0) {
-          this.stop.piiEntities = this.stop.piiEntities || []
+          this.stop.piiEntities = this.stop.piiEntities
+            ? this.stop.piiEntities.filter(
+                e => e.source !== this.basisForSearchSource,
+              )
+            : []
           for (const entity of response.piiEntities) {
-            entity.source = 'basisForSearch'
+            entity.source = this.basisForSearchSource
             this.stop.piiEntities.push(entity)
           }
         }

--- a/UI/src/components/mixins/RipaApiStopJobMixin.vue
+++ b/UI/src/components/mixins/RipaApiStopJobMixin.vue
@@ -50,7 +50,6 @@ export default {
           const apiStop = apiStops[index]
           if (apiStop.telemetry.offline) {
             for (const person of apiStop.listPersonStopped) {
-              console.log(person)
               let trimmedTextValue = person.basisForSearchBrief
                 ? person.basisForSearchBrief.trim()
                 : ''

--- a/UI/src/components/mixins/RipaFormContainerMixin.vue
+++ b/UI/src/components/mixins/RipaFormContainerMixin.vue
@@ -488,6 +488,7 @@ export default {
         updatedFullStop.stepTrace = this.stop.stepTrace
         updatedFullStop.location = this.stop.location
         updatedFullStop.stopDate = this.stop.stopDate
+        updatedFullStop.piiEntities = this.stop.piiEntities
         updatedFullStop.editStopExplanation =
           this.stop.editStopExplanation || null
         updatedFullStop.overridePii = this.stop.overridePii || false
@@ -583,30 +584,6 @@ export default {
           )
         }
       }
-    },
-
-    'stop.location.fullAddress': {
-      handler(newVal, oldVal) {
-        if (oldVal !== newVal) {
-          this.validateLocationForPii(newVal)
-        }
-      },
-    },
-
-    'stop.stopReason.reasonForStopExplanation': {
-      handler(newVal, oldVal) {
-        if (oldVal !== newVal) {
-          this.validateReasonForStopForPii(newVal)
-        }
-      },
-    },
-
-    'stop.actionsTaken.basisForSearchExplanation': {
-      handler(newVal, oldVal) {
-        if (oldVal !== newVal) {
-          this.validateBasisForSearchForPii(newVal)
-        }
-      },
     },
   },
 }

--- a/UI/src/components/mixins/RipaModelMixin.vue
+++ b/UI/src/components/mixins/RipaModelMixin.vue
@@ -13,6 +13,7 @@ export default {
         template: newValue.template,
         editStopExplanation: newValue.editStopExplanation || null,
         overridePii: newValue.overridePii || false,
+        piiEntities: newValue.piiEntities,
         stepTrace: newValue.stepTrace || [],
         actionsTaken: {
           anyActionsTaken: newValue.actionsTaken?.anyActionsTaken || false,

--- a/UI/src/components/molecules/RipaActionsTaken.vue
+++ b/UI/src/components/molecules/RipaActionsTaken.vue
@@ -89,7 +89,7 @@
                   label="Brief Explanation"
                   :loading="loadingPii"
                   :rules="explanationRules"
-                  @input="handleInput"
+                  @input="handleInput($event), handlePiiCheck($event)"
                 ></ripa-text-input>
               </template>
             </template>
@@ -354,6 +354,10 @@ export default {
     handleInput() {
       this.updateModel()
       this.$emit('input', this.viewModel)
+    },
+
+    handlePiiCheck(textValue) {
+      this.$emit('pii-check', { source: 'search', value: textValue })
     },
   },
 

--- a/UI/src/components/molecules/RipaFormStep1.vue
+++ b/UI/src/components/molecules/RipaFormStep1.vue
@@ -48,6 +48,7 @@
       :on-open-statute="onOpenStatute"
       :on-save-favorite="onSaveFavorite"
       :on-gps-location="onGpsLocation"
+      @pii-check="handlePiiCheck"
     ></ripa-location>
 
     <v-spacer></v-spacer>
@@ -176,6 +177,10 @@ export default {
         'ripa_form_submitted_api_stop',
         JSON.stringify(parsedApiStop),
       )
+    },
+
+    handlePiiCheck({ source, value }) {
+      this.$emit('pii-check', { source, value })
     },
   },
 

--- a/UI/src/components/molecules/RipaFormStep3.vue
+++ b/UI/src/components/molecules/RipaFormStep3.vue
@@ -9,6 +9,7 @@
       :on-open-favorites="onOpenFavorites"
       :on-open-statute="onOpenStatute"
       :on-save-favorite="onSaveFavorite"
+      @pii-check="handlePiiCheck"
     ></ripa-stop-reason>
 
     <v-spacer></v-spacer>
@@ -78,6 +79,10 @@ export default {
 
     handleCloseDialog() {
       this.showConfirmDialog = false
+    },
+
+    handlePiiCheck({ source, value }) {
+      this.$emit('pii-check', { source, value })
     },
   },
 

--- a/UI/src/components/molecules/RipaFormStep4.vue
+++ b/UI/src/components/molecules/RipaFormStep4.vue
@@ -4,6 +4,7 @@
       v-model="model"
       :loading-pii="loadingPii"
       :on-open-statute="onOpenStatute"
+      @pii-check="handlePiiCheck"
     ></ripa-actions-taken>
 
     <ripa-contraband
@@ -85,6 +86,10 @@ export default {
 
     handleCloseDialog() {
       this.showConfirmDialog = false
+    },
+
+    handlePiiCheck({ source, value }) {
+      this.$emit('pii-check', { source, value })
     },
   },
 }

--- a/UI/src/components/molecules/RipaLocation.vue
+++ b/UI/src/components/molecules/RipaLocation.vue
@@ -128,7 +128,7 @@
               label="Street Name"
               :loading="loadingPii"
               :rules="streetNameRules"
-              @input="handleInput"
+              @input="handleInput($event), handlePiiCheck($event)"
             >
             </ripa-text-input>
           </div>
@@ -144,7 +144,7 @@
             label="Closest Intersection"
             :loading="loadingPii"
             :rules="intersectionRules"
-            @input="handleInput"
+            @input="handleInput($event), handlePiiCheck($event)"
           >
           </ripa-text-input>
 
@@ -163,7 +163,7 @@
               label="Highway and closest exit"
               :loading="loadingPii"
               :rules="highwayRules"
-              @input="handleInput"
+              @input="handleInput($event), handlePiiCheck($event)"
             >
             </ripa-text-input>
 
@@ -173,7 +173,7 @@
               v-model="model.location.landmark"
               label="Road marker, landmark, or other"
               :rules="landmarkRules"
-              @input="handleInput"
+              @input="handleInput($event), handlePiiCheck($event)"
             >
             </ripa-text-input>
           </template>
@@ -404,6 +404,10 @@ export default {
     handleInput() {
       this.updateModel()
       this.$emit('input', this.viewModel)
+    },
+
+    handlePiiCheck(textValue) {
+      this.$emit('pii-check', { source: 'location', value: textValue })
     },
 
     handleInputOutOfCounty(newVal) {

--- a/UI/src/components/molecules/RipaOverridePii.vue
+++ b/UI/src/components/molecules/RipaOverridePii.vue
@@ -7,6 +7,26 @@
         <v-col cols="12" sm="12">
           Is PII Found: {{ apiStop.isPiiFound }}
         </v-col>
+        <v-col v-if="apiStop.isPiiFound" cols="12" sm="12">
+          <v-simple-table>
+            <template v-slot:default>
+              <thead>
+                <tr>
+                  <th>PII Item</th>
+                  <th>PII Category</th>
+                  <th>Source</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="item in apiStop.piiEntities" :key="item.entityText">
+                  <td>{{ item.entityText }}</td>
+                  <td>{{ item.category }}</td>
+                  <td>{{ item.source }}</td>
+                </tr>
+              </tbody>
+            </template>
+          </v-simple-table>
+        </v-col>
         <v-col cols="12" sm="12">
           <ripa-switch
             v-model="model.overridePii"

--- a/UI/src/components/molecules/RipaOverridePii.vue
+++ b/UI/src/components/molecules/RipaOverridePii.vue
@@ -18,7 +18,7 @@
                 </tr>
               </thead>
               <tbody>
-                <tr v-for="item in apiStop.piiEntities" :key="item.entityText">
+                <tr v-for="(item, index) in apiStop.piiEntities" :key="index">
                   <td>{{ item.entityText }}</td>
                   <td>{{ item.category }}</td>
                   <td>{{ item.source }}</td>

--- a/UI/src/components/molecules/RipaStopReason.vue
+++ b/UI/src/components/molecules/RipaStopReason.vue
@@ -156,7 +156,7 @@
             label="Brief Explanation"
             :loading="loadingPii"
             :rules="explanationRules"
-            @input="handleInput"
+            @input="handleInput($event), handlePiiCheck($event)"
           ></ripa-text-input>
         </v-col>
       </v-row>
@@ -310,6 +310,10 @@ export default {
       if (this.onSaveFavorite) {
         this.onSaveFavorite(this.viewModel.stopReason)
       }
+    },
+
+    handlePiiCheck(textValue) {
+      this.$emit('pii-check', { source: 'reason', value: textValue })
     },
   },
 

--- a/UI/src/components/organisms/RipaFormWrapper.vue
+++ b/UI/src/components/organisms/RipaFormWrapper.vue
@@ -76,6 +76,7 @@
                     :on-gps-location="onGpsLocation"
                     :on-update-user="onUpdateUser"
                     @input="handleInput"
+                    @pii-check="handlePiiCheck"
                   ></ripa-form-step-1>
                 </template>
               </v-stepper-content>
@@ -122,6 +123,7 @@
                     :on-save-favorite="onSaveReasonFavorite"
                     :statutes="statutes"
                     @input="handleInput"
+                    @pii-check="handlePiiCheck"
                   ></ripa-form-step-3>
                 </template>
               </v-stepper-content>
@@ -143,6 +145,7 @@
                     :on-open-statute="onOpenStatute"
                     :statutes="statutes"
                     @input="handleInput"
+                    @pii-check="handlePiiCheck"
                   ></ripa-form-step-4>
                 </template>
               </v-stepper-content>
@@ -428,6 +431,10 @@ export default {
     handleInput(newVal) {
       this.stop = Object.assign({}, newVal)
       this.$emit('input', this.stop)
+    },
+
+    handlePiiCheck({ source, value }) {
+      this.$emit('pii-check', { source, value })
     },
 
     handleAddPerson() {

--- a/UI/src/components/templates/RipaFormTemplate.vue
+++ b/UI/src/components/templates/RipaFormTemplate.vue
@@ -47,6 +47,7 @@
       :on-submit-audit="onSubmitAudit"
       :on-update-user="onUpdateUser"
       @input="handleInput"
+      @pii-check="handlePiiCheck"
     ></ripa-form-wrapper>
   </div>
 </template>
@@ -71,6 +72,10 @@ export default {
     handleInput(newVal) {
       this.stop = Object.assign({}, newVal)
       this.$emit('input', this.stop)
+    },
+
+    handlePiiCheck({ source, value }) {
+      this.$emit('pii-check', { source, value })
     },
   },
 

--- a/UI/src/store/index.js
+++ b/UI/src/store/index.js
@@ -1222,6 +1222,7 @@ export default new Vuex.Store({
           },
         })
         .then(response => {
+          console.log(response.data.stops)
           commit('updateAdminStops', {
             summary: response.data.summary,
             stops: response.data.stops,

--- a/UI/src/store/index.js
+++ b/UI/src/store/index.js
@@ -1221,7 +1221,6 @@ export default new Vuex.Store({
           },
         })
         .then(response => {
-          console.log(response.data.stops)
           commit('updateAdminStops', {
             summary: response.data.summary,
             stops: response.data.stops,

--- a/UI/src/store/index.js
+++ b/UI/src/store/index.js
@@ -507,7 +507,7 @@ export default new Vuex.Store({
         .then(response => {
           const data = response.data
           commit('updatePiiDate')
-          return data && data.piiEntities && data.piiEntities.length > 0
+          return data
         })
         .catch(error => {
           console.log('There was an error checking for PII.', error)

--- a/UI/src/utilities/stop.js
+++ b/UI/src/utilities/stop.js
@@ -1137,6 +1137,7 @@ export const fullStopToApiStop = (
     },
     listAgencyQuestion: fullStop.agencyQuestions || [],
     isPiiFound: getPiiFound(parsedApiStop, fullStop, onlineAndAuthenticated),
+    piiEntities: fullStop.piiEntities,
     listPersonStopped: getApiStopPeopleListed(fullStop, statutes),
     location: {
       beat: getBeat(fullStop, beats),

--- a/UI/src/utilities/stop.js
+++ b/UI/src/utilities/stop.js
@@ -803,6 +803,7 @@ export const apiStopToFullStop = apiStop => {
     internalId: nanoid(),
     template: apiStop.telemetry?.template || null,
     stepTrace: apiStop.telemetry?.listStepTrace || [],
+    piiEntities: apiStop.piiEntities,
     location: {
       isSchool: apiStop.location?.school || false,
       school: schoolNumber ? Number(schoolNumber) : null,
@@ -1055,6 +1056,7 @@ export const fullStopToStop = fullStop => {
     template: fullStop.template,
     editStopExplanation: null,
     overridePii: false,
+    piiEntities: fullStop.piiEntities,
     stepTrace: fullStop.stepTrace,
     actionsTaken: person.actionsTaken || {},
     location: fullStop.location,


### PR DESCRIPTION
Checking for PII now happens at the component level to reduce the amount of calls to the API.  When PII is found the PII entities are attached to the stop in order to display what text created the PII flag.  On the admin edit screen, a table of PII entities is displayed below the Is PII Found flag.