### PR TITLE
Add local network dev and text-align left for time picker

### DIFF
--- a/UI/package.json
+++ b/UI/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve --host localhost --port 4000",
+    "serve": "vue-cli-service serve --port 4000",
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
     "test:unit-update": "vue-cli-service test:unit -u",

--- a/UI/src/components/atoms/RipaTimePicker.vue
+++ b/UI/src/components/atoms/RipaTimePicker.vue
@@ -1,6 +1,5 @@
 <template>
   <v-text-field
-    class="left-align"
     v-model="model"
     :label="label"
     :rules="rules"
@@ -71,7 +70,7 @@ export default {
   color: transparent;
   background: transparent;
 }
-.left-align input {
+input::-webkit-date-and-time-value {
   text-align: left;
 }
 </style>

--- a/UI/vue.config.js
+++ b/UI/vue.config.js
@@ -1,6 +1,8 @@
 module.exports = {
   transpileDependencies: ['vuetify'],
-
+  devServer: {
+    https: true,
+  },
   publicPath: './',
   configureWebpack: {
     devtool: 'source-map',


### PR DESCRIPTION
Not pressing, allows local development and aligns the time picker text on iOS mobile to the left.