### PR TITLE
Delete and Repopulate User Table

### DIFF
--- a/Deployment/Scripts/User-Permissions-Sync.ps1
+++ b/Deployment/Scripts/User-Permissions-Sync.ps1
@@ -10,8 +10,6 @@ $shdKeyVaultName = "kv-cssa-it-ops-shd-001"
 $userObjectId = ((az keyvault secret show --subscription $shdKeyVaultSubscription --vault-name $shdKeyVaultName -n cssa-marketplace-deployment-spn) | ConvertFrom-Json).value
 $userPassword = ((az keyvault secret show --subscription $shdKeyVaultSubscription --vault-name $shdKeyVaultName -n cssa-marketplace-deployment-pwd) | ConvertFrom-Json).value
 
-
-
 ## Sign into Azure w/ Service Principal
 Write-Host "Logging into Azure Cloud"
 az cloud set -n AzureUSGovernment
@@ -58,7 +56,13 @@ foreach ($group in $ripaDashboardReaders) {
     $agency = $group.displayName.Split("-")[0]; # take first section of display name to get agency name
     $agencySubscription = $subscriptions | Where-Object -FilterScript { $_.name -eq "$agency-$environment" }
     Write-Host "subscription:" $agencySubscription.displayName $agencySubscription.id
-    
+        
+    if ($null -eq $agencySubscription){
+        # can't find sub from query. warn user & move on
+        Write-Warning "no subscription found for $agency-$environment" 
+        continue
+    }
+
     # get the ORI code
     $subid = "/subscriptions/" + $agencySubscription.id
     $tagList = (az tag list --resource-id $subid) | ConvertFrom-Json

--- a/Deployment/Scripts/User-Permissions-Sync.ps1
+++ b/Deployment/Scripts/User-Permissions-Sync.ps1
@@ -41,11 +41,13 @@ $sqlConn.Open()
 Write-Host "Connected to database"
 
 # delete ALL entries in db
-$delSql = "delete from [model].[dimSecurity]"
+Write-Host "Truncating the user table"
+$delSql = "truncate table [model].[dimSecurity]"
 $delcmd = New-Object Data.SqlClient.SqlCommand
 $delcmd.Connection = $sqlConn
 $delcmd.CommandText = $delSql
 $delcmd.ExecuteNonQuery() | Out-Null
+Write-Host "All records removed"
 
 # iterate thru groups
 foreach ($group in $ripaDashboardReaders) {
@@ -108,9 +110,7 @@ foreach ($group in $ripaDashboardReaders) {
             # nack out
             Write-Host $_
             Write-Error $member.displayName "was not added to db" 
-
-        }
-        
+        }        
     }    
 }
 


### PR DESCRIPTION
Modified script so that it Truncates the DimSecurity table before repopulating with current users
Added a null check to the subscription query that warns the operator that a given $agencyName-$environment combo doesn't return anything