### PR TITLE
fix: When reason for search is only condition of parole for V2 stop, …

### DIFF
--- a/UI/src/components/molecules/RipaNonForceActionsTaken.vue
+++ b/UI/src/components/molecules/RipaNonForceActionsTaken.vue
@@ -87,6 +87,11 @@
                 </template>
 
                 <ripa-text-input
+                  v-if="
+                    !this.model.nonForceActionsTaken.basisForSearch.every(
+                      reasonForSearchVal => reasonForSearchVal === 4,
+                    )
+                  "
                   v-model="model.nonForceActionsTaken.basisForSearchExplanation"
                   hint="Important: Do not include personally identifying information, such as names, DOBs, addresses, ID numbers, etc."
                   persistent-hint


### PR DESCRIPTION
…hide explanation field

[AB#3105](https://dev.azure.com/dsd-sdsd/ad8a8cd2-ef49-4e7c-bae2-6f8729a38334/_workitems/edit/3105)