### PR TITLE
force v2 get stops query string calculation to consider sum of v1 get stops result

### DIFF
--- a/Functions/RIPA.Functions.Common.Services/Stop/Utility/StopQueryUtility.cs
+++ b/Functions/RIPA.Functions.Common.Services/Stop/Utility/StopQueryUtility.cs
@@ -42,7 +42,7 @@ public class StopQueryUtility
         return stopQuery;
     }
 
-    public string GetStopsQueryString(StopQuery stopQuery, bool isVisible, int version, bool forCpraReport = false)
+    public string GetStopsQueryString(StopQuery stopQuery, bool isVisible, int version, bool forCpraReport = false, int v1count = 0)
     {
         List<string> whereStatements = new List<string>();
         string join = string.Empty;
@@ -141,7 +141,7 @@ public class StopQueryUtility
             // Limit and Offset
             if (stopQuery.Limit != 0)
             {
-                limit = Environment.NewLine + $"OFFSET {stopQuery.Offset} LIMIT {stopQuery.Limit}";
+                limit = Environment.NewLine + $"OFFSET {stopQuery.Offset} LIMIT {stopQuery.Limit - v1count}";
             }
 
             // Order and OrderBy               

--- a/Functions/RIPA.Functions.Common.Services/Stop/Utility/StopQueryUtility.cs
+++ b/Functions/RIPA.Functions.Common.Services/Stop/Utility/StopQueryUtility.cs
@@ -42,7 +42,7 @@ public class StopQueryUtility
         return stopQuery;
     }
 
-    public string GetStopsQueryString(StopQuery stopQuery, bool isVisible, int version, bool forCpraReport = false, int v1count = 0)
+    public string GetStopsQueryString(StopQuery stopQuery, bool isVisible, int version, bool forCpraReport = false, int v1Count = 0)
     {
         List<string> whereStatements = new List<string>();
         string join = string.Empty;
@@ -141,7 +141,7 @@ public class StopQueryUtility
             // Limit and Offset
             if (stopQuery.Limit != 0)
             {
-                limit = Environment.NewLine + $"OFFSET {stopQuery.Offset} LIMIT {stopQuery.Limit - v1count}";
+                limit = Environment.NewLine + $"OFFSET {stopQuery.Offset} LIMIT {stopQuery.Limit - v1Count}";
             }
 
             // Order and OrderBy               

--- a/Functions/RIPA.Functions.Stop/Functions/v1/GetStops.cs
+++ b/Functions/RIPA.Functions.Stop/Functions/v1/GetStops.cs
@@ -63,29 +63,23 @@ public class GetStops
             log.LogError(ex.Message);
             return new UnauthorizedResult();
         }
+
         List<IStop> stopResponse = new();
         IEnumerable<StopStatusCount> stopStatusCounts;
         string stopV1QueryString = string.Empty;
         string stopV2QueryString = string.Empty;
         string stopSummaryQueryString = string.Empty;
-        int Limit = !string.IsNullOrWhiteSpace(req.Query["Limit"]) ? Convert.ToInt32(req.Query["Limit"]) : default;
+
         try
         {
             StopQueryUtility stopQueryUtility = new StopQueryUtility();
             StopQuery stopQuery = stopQueryUtility.GetStopQuery(req);
-
-            
-
             try
             {
                 stopV1QueryString = stopQueryUtility.GetStopsQueryString(stopQuery, true, 1);
                 stopResponse.AddRange(await _stopV1CosmosDbService.GetStopsAsync(stopV1QueryString));
-
-                
-
                 stopV2QueryString = stopQueryUtility.GetStopsQueryString(stopQuery, true, 2, false, stopResponse.Count);
                 stopResponse.AddRange(await _stopV2CosmosDbService.GetStopsAsync(stopV2QueryString));
-
                 stopSummaryQueryString = stopQueryUtility.GetStopsSummaryQueryString(stopQuery);
                 stopStatusCounts = await _stopV1CosmosDbService.GetStopStatusCounts(stopSummaryQueryString);
             }
@@ -94,16 +88,12 @@ public class GetStops
                 log.LogError(ex, "An error occurred getting stops requested.");
                 return new BadRequestObjectResult("An error occurred getting stops requested. Please try again.");
             }
-
         }
         catch (Exception ex)
         {
             log.LogError("An error occured while evaluating the stop query.", ex);
             return new BadRequestObjectResult("An error occured while evaluating the stop query. Please try again.");
         }
-
-       
-
 
         var response = new
         {

--- a/Functions/RIPA.Functions.Stop/Functions/v2/GetStops.cs
+++ b/Functions/RIPA.Functions.Stop/Functions/v2/GetStops.cs
@@ -63,39 +63,43 @@ public class GetStops
             log.LogError(ex.Message);
             return new UnauthorizedResult();
         }
-
+        List<IStop> stopResponse = new();
+        IEnumerable<StopStatusCount> stopStatusCounts;
         string stopV1QueryString = string.Empty;
         string stopV2QueryString = string.Empty;
         string stopSummaryQueryString = string.Empty;
-
+        int Limit = !string.IsNullOrWhiteSpace(req.Query["Limit"]) ? Convert.ToInt32(req.Query["Limit"]) : default;
         try
         {
             StopQueryUtility stopQueryUtility = new StopQueryUtility();
             StopQuery stopQuery = stopQueryUtility.GetStopQuery(req);
-            stopV1QueryString = stopQueryUtility.GetStopsQueryString(stopQuery, true, 1);
-            stopV2QueryString = stopQueryUtility.GetStopsQueryString(stopQuery, true, 2);
-            stopSummaryQueryString = stopQueryUtility.GetStopsSummaryQueryString(stopQuery);
+
+
+
+            try
+            {
+                stopV1QueryString = stopQueryUtility.GetStopsQueryString(stopQuery, true, 1);
+                stopResponse.AddRange(await _stopV1CosmosDbService.GetStopsAsync(stopV1QueryString));
+
+
+
+                stopV2QueryString = stopQueryUtility.GetStopsQueryString(stopQuery, true, 2, false, stopResponse.Count);
+                stopResponse.AddRange(await _stopV2CosmosDbService.GetStopsAsync(stopV2QueryString));
+
+                stopSummaryQueryString = stopQueryUtility.GetStopsSummaryQueryString(stopQuery);
+                stopStatusCounts = await _stopV1CosmosDbService.GetStopStatusCounts(stopSummaryQueryString);
+            }
+            catch (Exception ex)
+            {
+                log.LogError(ex, "An error occurred getting stops requested.");
+                return new BadRequestObjectResult("An error occurred getting stops requested. Please try again.");
+            }
+
         }
         catch (Exception ex)
         {
             log.LogError("An error occured while evaluating the stop query.", ex);
             return new BadRequestObjectResult("An error occured while evaluating the stop query. Please try again.");
-        }
-
-        List<IStop> stopResponse = new();
-        IEnumerable<StopStatusCount> stopStatusCounts;
-
-        try
-        {
-            stopResponse.AddRange(await _stopV1CosmosDbService.GetStopsAsync(stopV1QueryString));
-            stopResponse.AddRange(await _stopV2CosmosDbService.GetStopsAsync(stopV2QueryString));
-
-            stopStatusCounts = await _stopV1CosmosDbService.GetStopStatusCounts(stopSummaryQueryString);
-        }
-        catch (Exception ex)
-        {
-            log.LogError(ex, "An error occurred getting stops requested.");
-            return new BadRequestObjectResult("An error occurred getting stops requested. Please try again.");
         }
 
         var response = new

--- a/Functions/RIPA.Functions.Stop/Functions/v2/GetStops.cs
+++ b/Functions/RIPA.Functions.Stop/Functions/v2/GetStops.cs
@@ -63,29 +63,23 @@ public class GetStops
             log.LogError(ex.Message);
             return new UnauthorizedResult();
         }
+
         List<IStop> stopResponse = new();
         IEnumerable<StopStatusCount> stopStatusCounts;
         string stopV1QueryString = string.Empty;
         string stopV2QueryString = string.Empty;
         string stopSummaryQueryString = string.Empty;
-        int Limit = !string.IsNullOrWhiteSpace(req.Query["Limit"]) ? Convert.ToInt32(req.Query["Limit"]) : default;
+
         try
         {
             StopQueryUtility stopQueryUtility = new StopQueryUtility();
             StopQuery stopQuery = stopQueryUtility.GetStopQuery(req);
-
-
-
             try
             {
                 stopV1QueryString = stopQueryUtility.GetStopsQueryString(stopQuery, true, 1);
                 stopResponse.AddRange(await _stopV1CosmosDbService.GetStopsAsync(stopV1QueryString));
-
-
-
                 stopV2QueryString = stopQueryUtility.GetStopsQueryString(stopQuery, true, 2, false, stopResponse.Count);
                 stopResponse.AddRange(await _stopV2CosmosDbService.GetStopsAsync(stopV2QueryString));
-
                 stopSummaryQueryString = stopQueryUtility.GetStopsSummaryQueryString(stopQuery);
                 stopStatusCounts = await _stopV1CosmosDbService.GetStopStatusCounts(stopSummaryQueryString);
             }
@@ -94,7 +88,6 @@ public class GetStops
                 log.LogError(ex, "An error occurred getting stops requested.");
                 return new BadRequestObjectResult("An error occurred getting stops requested. Please try again.");
             }
-
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Created new variable in v1 and v2 get stops method, "v1Count" as a parameter of the getstopquerystring utility method.

[AB#2911](https://dev.azure.com/dsd-sdsd/ad8a8cd2-ef49-4e7c-bae2-6f8729a38334/_workitems/edit/2911)