### PR TITLE
fix: nonbinary person switch not mapping when editing stop

### DIFF
--- a/UI/src/components/features/RipaFormContainer.vue
+++ b/UI/src/components/features/RipaFormContainer.vue
@@ -914,6 +914,7 @@ export default {
           perceivedOrKnownDisability:
             filteredPerson?.perceivedOrKnownDisability || [],
           perceivedRace: filteredPerson?.perceivedRace || [],
+          nonBinaryPerson: filteredPerson?.nonBinaryPerson,
         },
         stopReason: filteredPerson?.stopReason || {},
         stopResult: filteredPerson?.stopResult || {},

--- a/UI/src/utilities/stop.js
+++ b/UI/src/utilities/stop.js
@@ -1515,7 +1515,7 @@ const getStopReasonSearchOfPersonV2 = person => {
 
   if (reasonForStop === 6) {
     if (anyActionsTaken) {
-      if (mappedActionsTaken.includes(18)) {
+      if (mappedActionsTaken.includes(14)) {
         return true
       }
     }
@@ -1553,7 +1553,7 @@ const getStopReasonSearchOfPropertyV2 = person => {
 
   if (reasonForStop === 6) {
     if (anyActionsTaken) {
-      if (mappedActionsTaken.includes(20)) {
+      if (mappedActionsTaken.includes(15)) {
         return true
       }
     }


### PR DESCRIPTION
- fix validation bug that doesn't allow you to continue editing a stop where "nonbinary person" is selected without a perceived gender

- fix a validation bug where search of person and search of property switch isn't mapping properly while editing stop