### PR TITLE
Task/4679 late stop submission

### DIFF
--- a/Functions/RIPA.Functions.Common.Models/v2/Stop.cs
+++ b/Functions/RIPA.Functions.Common.Models/v2/Stop.cs
@@ -62,5 +62,6 @@ public class Stop : IStop
     public string FavoriteReasonName { get; set; }
     public string FavoriteResultName { get; set; }
     public bool? Nfia { get; set; }
-    public string LateStopExplanation { get; set; }
+    public bool? LateSubmission { get; set; }
+    public string LateSubmissionExplanation { get; set; }
 }

--- a/Functions/RIPA.Functions.Common.Models/v2/Stop.cs
+++ b/Functions/RIPA.Functions.Common.Models/v2/Stop.cs
@@ -62,4 +62,5 @@ public class Stop : IStop
     public string FavoriteReasonName { get; set; }
     public string FavoriteResultName { get; set; }
     public bool? Nfia { get; set; }
+    public string LateStopExplanation { get; set; }
 }

--- a/Functions/RIPA.Functions.Common.Models/v2/Stop.cs
+++ b/Functions/RIPA.Functions.Common.Models/v2/Stop.cs
@@ -62,6 +62,5 @@ public class Stop : IStop
     public string FavoriteReasonName { get; set; }
     public string FavoriteResultName { get; set; }
     public bool? Nfia { get; set; }
-    public bool? LateSubmission { get; set; }
     public string LateSubmissionExplanation { get; set; }
 }

--- a/UI/src/components/features/RipaFormContainer.vue
+++ b/UI/src/components/features/RipaFormContainer.vue
@@ -1142,8 +1142,8 @@ export default {
         updatedFullStop.stepTrace = this.stop.stepTrace
         updatedFullStop.location = this.stop.location
         updatedFullStop.stopDate = this.stop.stopDate
-        updatedFullStop.lateStopExplanation =
-          this.stop.lateStopExplanation || null
+        updatedFullStop.lateSubmissionExplanation =
+          this.stop.lateSubmissionExplanation || null
         updatedFullStop.piiEntities = this.stop.piiEntities
         updatedFullStop.isPiiFound = this.stop.isPiiFound
         updatedFullStop.officerWorksWithNonReportingAgency =

--- a/UI/src/components/features/RipaFormContainer.vue
+++ b/UI/src/components/features/RipaFormContainer.vue
@@ -1142,6 +1142,8 @@ export default {
         updatedFullStop.stepTrace = this.stop.stepTrace
         updatedFullStop.location = this.stop.location
         updatedFullStop.stopDate = this.stop.stopDate
+        updatedFullStop.lateStopExplanation =
+          this.stop.lateStopExplanation || null
         updatedFullStop.piiEntities = this.stop.piiEntities
         updatedFullStop.isPiiFound = this.stop.isPiiFound
         updatedFullStop.officerWorksWithNonReportingAgency =

--- a/UI/src/components/molecules/RipaStopDate.vue
+++ b/UI/src/components/molecules/RipaStopDate.vue
@@ -81,7 +81,7 @@
           </v-alert>
 
           <v-text-field
-            v-model="model.lateStopExplanation"
+            v-model="model.lateSubmissionExplanation"
             label="Explanation for Late Submission"
             :rules="lateExplanationRules"
             required

--- a/UI/src/components/molecules/RipaStopsGrid.vue
+++ b/UI/src/components/molecules/RipaStopsGrid.vue
@@ -248,6 +248,16 @@
           <template v-slot:item.isPiiFound="{ item }">
             {{ item.isPiiFound ? 'Yes' : 'No' }}
           </template>
+          <template v-slot:item.stopDateTime="{ item }">
+            <span>{{ item.stopDateTime }}</span>
+            <v-icon
+              v-if="item.lateSubmissionExplanation"
+              color="warning"
+              small
+              title="Late Submission"
+              >mdi-alert-circle</v-icon
+            >
+          </template>
         </v-data-table>
       </v-flex>
 

--- a/UI/src/utilities/stop.js
+++ b/UI/src/utilities/stop.js
@@ -155,6 +155,7 @@ export const defaultStop = () => {
       time: format(new Date(), 'kk:mm'),
       duration: null,
       stopInResponseToCFS: false,
+      lateSubmissionExplanation: null,
     },
     stopReason: stopReasonGivenTemplate(),
     stopResult: stopResultGivenTemplate(),
@@ -1242,6 +1243,7 @@ export const apiStopToFullStopV2 = apiStop => {
       time: apiStop.time,
       duration: Number(apiStop.stopDuration),
       stopInResponseToCFS: apiStop.stopInResponseToCFS || false,
+      lateSubmissionExplanation: apiStop.lateSubmissionExplanation || null,
     },
     people: getFullStopPeopleListedV2(apiStop),
   }
@@ -1730,6 +1732,7 @@ export const fullStopToStopV2 = fullStop => {
     stopReason: person.stopReason || {},
     stopResult: person.stopResult || {},
     agencyQuestions: fullStop.agencyQuestions,
+    lateSubmissionExplanation: fullStop.lateSubmissionExplanation || null,
   }
 }
 

--- a/UI/src/utilities/stop.js
+++ b/UI/src/utilities/stop.js
@@ -283,6 +283,9 @@ export const apiStopStopSummary = apiStop => {
       content: getSummaryStopMadeDuringWelfareCheck(apiStop),
     })
   }
+ 
+    items.push({ id: 'A11', content: getSummaryLateExplanation(apiStop) })
+ 
   return items
 }
 
@@ -319,6 +322,15 @@ const getSummaryDate = apiStop => {
     level: 1,
     header: 'Date',
     detail: apiStop.date,
+  }
+}
+
+const getSummaryLateExplanation = apiStop => {
+  return {
+    marginTop: true,
+    level: 1,
+    header: 'Late Stop Explanation',
+    detail: apiStop.lateStopExplanation,
   }
 }
 

--- a/UI/src/utilities/stop.js
+++ b/UI/src/utilities/stop.js
@@ -1825,6 +1825,7 @@ export const fullStopToApiStop = (
     time: fullStop.stopDate.time,
     stopVersion: fullStop.stopVersion,
     nfia: fullStop.nfia,
+    lateStopExplanation: fullStop.lateStopExplanation || null,
   }
 }
 
@@ -1942,6 +1943,7 @@ export const fullStopToApiStopV2 = (
     favoriteLocationName: fullStop.favoriteLocationName,
     favoriteReasonName: fullStop.favoriteReasonName,
     favoriteResultName: fullStop.favoriteResultName,
+    lateStopExplanation: fullStop.lateStopExplanation || null,
   }
 }
 

--- a/UI/src/utilities/stop.js
+++ b/UI/src/utilities/stop.js
@@ -283,9 +283,9 @@ export const apiStopStopSummary = apiStop => {
       content: getSummaryStopMadeDuringWelfareCheck(apiStop),
     })
   }
- 
+  if (apiStop.lateStopExplanation) {
     items.push({ id: 'A11', content: getSummaryLateExplanation(apiStop) })
- 
+  }
   return items
 }
 
@@ -327,7 +327,6 @@ const getSummaryDate = apiStop => {
 
 const getSummaryLateExplanation = apiStop => {
   return {
-    marginTop: true,
     level: 1,
     header: 'Late Stop Explanation',
     detail: apiStop.lateStopExplanation,

--- a/UI/src/utilities/stop.js
+++ b/UI/src/utilities/stop.js
@@ -283,7 +283,7 @@ export const apiStopStopSummary = apiStop => {
       content: getSummaryStopMadeDuringWelfareCheck(apiStop),
     })
   }
-  if (apiStop.lateStopExplanation) {
+  if (apiStop.lateSubmissionExplanation) {
     items.push({ id: 'A11', content: getSummaryLateExplanation(apiStop) })
   }
   return items
@@ -328,8 +328,8 @@ const getSummaryDate = apiStop => {
 const getSummaryLateExplanation = apiStop => {
   return {
     level: 1,
-    header: 'Late Stop Explanation',
-    detail: apiStop.lateStopExplanation,
+    header: 'Late Submission Explanation',
+    detail: apiStop.lateSubmissionExplanation,
   }
 }
 
@@ -1836,7 +1836,7 @@ export const fullStopToApiStop = (
     time: fullStop.stopDate.time,
     stopVersion: fullStop.stopVersion,
     nfia: fullStop.nfia,
-    lateStopExplanation: fullStop.lateStopExplanation || null,
+    lateSubmissionExplanation: fullStop.lateSubmissionExplanation || null,
   }
 }
 
@@ -1954,7 +1954,7 @@ export const fullStopToApiStopV2 = (
     favoriteLocationName: fullStop.favoriteLocationName,
     favoriteReasonName: fullStop.favoriteReasonName,
     favoriteResultName: fullStop.favoriteResultName,
-    lateStopExplanation: fullStop.lateStopExplanation || null,
+    lateSubmissionExplanation: fullStop.lateSubmissionExplanation || null,
   }
 }
 


### PR DESCRIPTION
This pull request introduces a new feature to handle late submission explanations for stops that are reported more than 24 hours after they occur. The changes span across multiple files, adding support for capturing, validating, displaying, and transmitting the late submission explanation field.

### Backend Changes:

* **Model Update**:
  - Added `LateSubmissionExplanation` property to the `Stop` model in `Functions/RIPA.Functions.Common.Models/v2/Stop.cs`.

### Frontend Changes:

#### UI Enhancements:
* **New Input Field**:
  - Added a `v-text-field` for users to provide an explanation for late submissions in `RipaStopDate.vue`. This field is conditionally displayed when the stop is submitted late.
  - Introduced a warning alert in `RipaStopDate.vue` to notify users about late submissions.

* **Validation Rules**:
  - Added `lateExplanationRules` in `RipaStopDate.vue` to ensure that an explanation is provided for late stops.

* **Indicator for Late Submissions**:
  - Updated `RipaStopsGrid.vue` to display a warning icon next to stops with a late submission explanation.

#### Data Handling:
* **Data Flow Updates**:
  - Updated `RipaFormContainer.vue` to include `lateSubmissionExplanation` in the stop data.
  - Modified utility functions in `stop.js` to handle the `lateSubmissionExplanation` field during data transformations:
    - Added `lateSubmissionExplanation` to default stop data.
    - Included `lateSubmissionExplanation` in API stop summary generation. [[1]](diffhunk://#diff-4243947f3dad4f19f3abee953665b30266a32cb6846c46c38b5570815dc85c82R287-R289) [[2]](diffhunk://#diff-4243947f3dad4f19f3abee953665b30266a32cb6846c46c38b5570815dc85c82R329-R336)
    - Updated data mapping functions (`apiStopToFullStopV2`, `fullStopToStopV2`, `fullStopToApiStop`, `fullStopToApiStopV2`) to handle the new field. [[1]](diffhunk://#diff-4243947f3dad4f19f3abee953665b30266a32cb6846c46c38b5570815dc85c82R1246) [[2]](diffhunk://#diff-4243947f3dad4f19f3abee953665b30266a32cb6846c46c38b5570815dc85c82R1735) [[3]](diffhunk://#diff-4243947f3dad4f19f3abee953665b30266a32cb6846c46c38b5570815dc85c82R1842) [[4]](diffhunk://#diff-4243947f3dad4f19f3abee953665b30266a32cb6846c46c38b5570815dc85c82R1960)