### PR TITLE
Task/4679 late stop submission

### DIFF
--- a/Functions/RIPA.Functions.Common.Models/v2/Stop.cs
+++ b/Functions/RIPA.Functions.Common.Models/v2/Stop.cs
@@ -62,5 +62,5 @@ public class Stop : IStop
     public string FavoriteReasonName { get; set; }
     public string FavoriteResultName { get; set; }
     public bool? Nfia { get; set; }
-    public string LateSubmissionExplanation { get; set; }
+    public string LateSubmissionExplanation { get; set; } = null;
 }

--- a/UI/src/components/molecules/RipaStopDate.vue
+++ b/UI/src/components/molecules/RipaStopDate.vue
@@ -75,19 +75,21 @@
 
       <v-row v-if="isLateStop" class="tw-mt-4">
         <v-col cols="12">
-          <v-alert type="warning" dense outlined>
+          <v-alert type="warning" dense outlined class="mt-2">
             This stop is being submitted more than 24 hours after it occurred.
             Please provide an explanation for the late submission.
           </v-alert>
+        </v-col>
+      </v-row>
 
+      <v-row v-if="isLateStop">
+        <v-col>
           <v-text-field
             v-model="model.lateSubmissionExplanation"
-            label="Explanation for Late Submission"
             :rules="lateExplanationRules"
+            label="Explanation for Late Submission"
             required
-            outlined
             dense
-            class="tw-mt-2"
           />
         </v-col>
       </v-row>

--- a/UI/src/components/molecules/RipaStopsGrid.vue
+++ b/UI/src/components/molecules/RipaStopsGrid.vue
@@ -252,10 +252,11 @@
             <span>{{ item.stopDateTime }}</span>
             <v-icon
               v-if="item.lateSubmissionExplanation"
+              title="Late Submission"
+              class="late-submission-icon"
               color="warning"
               small
-              title="Late Submission"
-              >mdi-alert-circle</v-icon
+              >mdi-clock-alert</v-icon
             >
           </template>
         </v-data-table>
@@ -726,5 +727,12 @@ export default {
 .custom-tooltip {
   opacity: var(--v-tooltip-opacity, 1) !important;
   background: var(--v-tooltip-bg, #1976d2) !important;
+}
+
+.late-submission-icon {
+  margin-left: 4px;
+  margin-bottom: 2px;
+  font-size: 18px !important;
+  vertical-align: middle;
 }
 </style>

--- a/UI/src/utilities/stop.js
+++ b/UI/src/utilities/stop.js
@@ -1220,6 +1220,7 @@ export const apiStopToFullStopV2 = apiStop => {
       apiStop.officerWorksWithNonReportingAgency,
     stopVersion: apiStop.stopVersion,
     stopMadeDuringWelfareCheck: apiStop.stopMadeDuringWelfareCheck,
+    lateSubmissionExplanation: apiStop.lateSubmissionExplanation || null,
     location: {
       isSchool: apiStop.location?.school || false,
       school: schoolNumber,
@@ -1243,7 +1244,6 @@ export const apiStopToFullStopV2 = apiStop => {
       time: apiStop.time,
       duration: Number(apiStop.stopDuration),
       stopInResponseToCFS: apiStop.stopInResponseToCFS || false,
-      lateSubmissionExplanation: apiStop.lateSubmissionExplanation || null,
     },
     people: getFullStopPeopleListedV2(apiStop),
   }


### PR DESCRIPTION
This pull request introduces enhancements to the handling and display of late submission explanations for stops, including UI updates, data model adjustments, and utility function improvements. The most notable changes involve refining the user interface for better usability, ensuring consistent handling of the `lateSubmissionExplanation` property, and improving visual indicators.

### UI Enhancements:
* Updated `RipaStopDate.vue` to add spacing and improve the layout of the late submission explanation input field. Adjusted the `v-alert` component to include a `class="mt-2"` for consistent spacing.
* Modified `RipaStopsGrid.vue` to replace the late submission icon with a new `mdi-clock-alert` icon and added a custom CSS class (`.late-submission-icon`) for better alignment and styling. [[1]](diffhunk://#diff-0e9a16fe311611b27defefc7f9e6ec161d0469ce33f580e8119d2f12617b13fcR255-R259) [[2]](diffhunk://#diff-0e9a16fe311611b27defefc7f9e6ec161d0469ce33f580e8119d2f12617b13fcR731-R737)

### Data Model Adjustments:
* Updated the `Stop.cs` model to explicitly initialize the `LateSubmissionExplanation` property to `null` by default.

### Utility Function Improvements:
* Adjusted `apiStopToFullStopV2` in `stop.js` to ensure consistent handling of the `lateSubmissionExplanation` property by moving it to the correct location in the mapping logic. [[1]](diffhunk://#diff-4243947f3dad4f19f3abee953665b30266a32cb6846c46c38b5570815dc85c82R1223) [[2]](diffhunk://#diff-4243947f3dad4f19f3abee953665b30266a32cb6846c46c38b5570815dc85c82L1246)